### PR TITLE
feat(java): require JDK 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and standard method from web, mobile and desktop applications.
 
 ### Getting started
 
-JDK 11 or later is required.
+JDK 17 or later is required.
 
 The samples below show how a published SDK artifact is used:
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ tasks.withType(Javadoc).configureEach {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.release = 11
+    options.release = 17
 }
 
 sourcesJar {
@@ -118,7 +118,7 @@ subprojects {
             withJavadocJar()
         }
         tasks.withType(JavaCompile).configureEach {
-            options.release = 11
+            options.release = 17
         }
 
         // Apply publishing configuration to all subprojects - they'll check for publishingConfig internally

--- a/gen.yaml
+++ b/gen.yaml
@@ -63,7 +63,7 @@ java:
       webhooks: models/webhooks
   inferUnionDiscriminators: false
   inputModelSuffix: input
-  languageVersion: 11
+  languageVersion: 17
   license:
     name: The MIT License (MIT)
     shortName: MIT


### PR DESCRIPTION
## Summary

- set the persistent Speakeasy Java target to Java 17
- compile the root SDK and Spring Boot starter modules with `--release 17`
- document JDK 17 as the minimum supported runtime

## Context

Speakeasy upgraded generated Spring Boot dependencies to a line that requires Java 17. Keeping `languageVersion: 11` causes the next generation to remove the Spring Boot starter modules.

## Validation

- `nix shell nixpkgs#jdk17 -c ./gradlew test`
- root SDK and both Spring Boot modules compiled successfully
- `git diff --check`

## Follow-up

Regenerate the SDK after this lands so Speakeasy can retain the Spring Boot starters with the Java 17 target.