### PR TITLE
chore: pin Speakeasy generator to 1.770.0

### DIFF
--- a/.github/workflows/speakeasy_sdk_generate.yml
+++ b/.github/workflows/speakeasy_sdk_generate.yml
@@ -14,7 +14,7 @@ jobs:
         with:
             force: ${{ github.event.inputs.force }}
             mode: pr
-            speakeasy_version: latest
+            speakeasy_version: 1.770.0
         secrets:
             github_access_token: ${{ secrets.GITHUB_TOKEN }}
             java_gpg_passphrase: ${{ secrets.JAVA_GPG_PASSPHRASE }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: latest
+speakeasyVersion: 1.770.0
 sources:
     stacks-source:
         inputs:


### PR DESCRIPTION
## Summary
- pin the Speakeasy workflow to CLI 1.770.0, matching the last published generation
- pin the GitHub generation runner to the same CLI version where configured
- keep generator upgrades isolated from OpenAPI contract updates

The corresponding generation engine recorded in `.speakeasy/gen.lock` is 2.893.0.

## Validation
- parsed the updated YAML files
- ran `git diff --check`